### PR TITLE
Ajuste no componente Home

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digital-blog",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digital-blog",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "axios": "^1.6.7",
         "react": "^18.2.0",

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,7 +20,7 @@ function Home() {
   return (
         <ul>
             {
-                posts.map( post => <li key={post.id}> <h4><Link to={`/posts${post.id}`}>{post.title}</Link></h4> <p>{post.body}</p> </li>)
+                posts.map( post => <li key={post.id}> <h4><Link to={`/posts/${post.id}`}>{post.title}</Link></h4> <p>{post.body}</p> </li>)
             }
         </ul>
     );


### PR DESCRIPTION
Ao tentar rodar todos os componentes/páginas, verifiquei que o componente Home não realizava a rota até as páginas conforme o usuário, apresentando assim uma página em branco. 

Dessa forma, verifiquei que link do React Router Dom não estava escrito corretamente, faltando uma separação de "/" entre o "posts" e o "${post.id}". Não estava funcionando tendo em vista que, nas rotas, estava definido o path "posts/::id". 